### PR TITLE
v0.3.0: New features (mute, stop, pitch, rate, language), bugfixes and enhancements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ data class Version(
     override fun toString() = name
 }
 
-val libVersion = Version(0, 2, 0)
+val libVersion = Version(0, 3, 0)
 
 group = "nl.marc.tts"
 version = libVersion.name

--- a/src/androidMain/kotlin/nl/marc/tts/Context.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/Context.kt
@@ -1,0 +1,5 @@
+package nl.marc.tts
+
+import android.content.Context as AndroidContext
+
+actual typealias Context = AndroidContext

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeech.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeech.kt
@@ -7,6 +7,7 @@ import android.os.Build.VERSION_CODES
 import android.speech.tts.TextToSpeech
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.jvm.Throws
 
 actual object TextToSpeech {
     actual val isSupported: Boolean = VERSION.SDK_INT >= VERSION_CODES.DONUT
@@ -50,7 +51,7 @@ actual object TextToSpeech {
      * Will throw an [TextToSpeechNotSupportedException] if TTS is not supported.
      */
     @Throws(TextToSpeechNotSupportedException::class)
-    fun createOrThrow(context: Context, callback: (TextToSpeechInstance) -> Unit) {
+    actual fun createOrThrow(context: Context, callback: (TextToSpeechInstance) -> Unit) {
         if(!isSupported) {
             throw TextToSpeechNotSupportedException()
         } else if (VERSION.SDK_INT >= VERSION_CODES.DONUT) {
@@ -66,7 +67,7 @@ actual object TextToSpeech {
      * Creates a new [TextToSpeech] instance.
      * Will return null if TTS is not supported.
      */
-    fun createOrNull(context: Context, callback: (TextToSpeechInstance?) -> Unit) {
+    actual fun createOrNull(context: Context, callback: (TextToSpeechInstance?) -> Unit) {
         if(!isSupported) {
             callback(null)
         } else if (VERSION.SDK_INT >= VERSION_CODES.DONUT) {

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -10,7 +10,7 @@ import java.io.Closeable
 import android.speech.tts.TextToSpeech as AndroidTTS
 
 @TargetApi(VERSION_CODES.DONUT)
-internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechInstance, Closeable {
+internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechInstance {
     override var volume: Int = 100
         set(value) {
             if(TextToSpeech.canChangeVolume)

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -30,6 +30,18 @@ internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechIn
                 field = value
         }
 
+    override var pitch: Float = 1f
+        set(value) {
+            field = value
+            tts.setPitch(value)
+        }
+
+    override var rate: Float = 1f
+        set(value) {
+            field = value
+            tts.setSpeechRate(value)
+        }
+
     override fun say(text: String, clearQueue: Boolean) {
         val queueMode = if(clearQueue) AndroidTTS.QUEUE_FLUSH else AndroidTTS.QUEUE_ADD
         if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -14,6 +14,10 @@ internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechIn
     private val internalVolume: Float
         get() = if(!isMuted) volume / 100f else 0f
 
+    /**
+     * The output volume, which is 100(%) by default.
+     * Value is minimally 0, maximally 100 (although some platforms may allow higher values).
+     */
     override var volume: Int = 100
         set(value) {
             if(TextToSpeech.canChangeVolume)
@@ -40,17 +44,19 @@ internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechIn
         }
     }
 
+    /** Clears the internal queue, but doesn't close used resources. */
     override fun stop() {
         tts.stop()
     }
 
+    /** Clears the internal queue and closes used resources (if possible) */
     override fun close() {
         tts.stop()
         tts.shutdown()
     }
 
     companion object {
-        const val KEY_PARAM_VOLUME = "volume"
+        private const val KEY_PARAM_VOLUME = "volume"
     }
 }
 

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -7,6 +7,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import java.io.Closeable
+import java.util.*
 import android.speech.tts.TextToSpeech as AndroidTTS
 
 @TargetApi(VERSION_CODES.DONUT)
@@ -41,6 +42,16 @@ internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechIn
             field = value
             tts.setSpeechRate(value)
         }
+
+    private val voiceLocale: Locale
+        get() = if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) tts.voice.locale else tts.language
+
+    /**
+     * Returns a BCP 47 language tag of the selected voice on supported platforms.
+     * May return the language code as ISO 639 on older platforms.
+     */
+    override val language: String
+        get() = if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) voiceLocale.toLanguageTag() else voiceLocale.language
 
     override fun say(text: String, clearQueue: Boolean) {
         val queueMode = if(clearQueue) AndroidTTS.QUEUE_FLUSH else AndroidTTS.QUEUE_ADD

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -11,7 +11,16 @@ import android.speech.tts.TextToSpeech as AndroidTTS
 
 @TargetApi(VERSION_CODES.DONUT)
 internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechInstance {
+    private val internalVolume: Float
+        get() = if(!isMuted) volume / 100f else 0f
+
     override var volume: Int = 100
+        set(value) {
+            if(TextToSpeech.canChangeVolume)
+                field = value
+        }
+
+    override var isMuted: Boolean = false
         set(value) {
             if(TextToSpeech.canChangeVolume)
                 field = value
@@ -21,14 +30,18 @@ internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechIn
         val queueMode = if(clearQueue) AndroidTTS.QUEUE_FLUSH else AndroidTTS.QUEUE_ADD
         if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
             val params = Bundle()
-            params.putFloat(KEY_PARAM_VOLUME, volume / 100f)
+            params.putFloat(KEY_PARAM_VOLUME, internalVolume)
             tts.speak(text, queueMode, params, null)
         } else {
             val params = hashMapOf(
-                KEY_PARAM_VOLUME to (volume / 100f).toString()
+                KEY_PARAM_VOLUME to internalVolume.toString()
             )
             tts.speak(text, queueMode, params)
         }
+    }
+
+    override fun stop() {
+        tts.stop()
     }
 
     override fun close() {

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechAndroid.kt
@@ -6,11 +6,16 @@ import android.annotation.TargetApi
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
+import java.io.Closeable
 import android.speech.tts.TextToSpeech as AndroidTTS
 
 @TargetApi(VERSION_CODES.DONUT)
-internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechInstance {
+internal class TextToSpeechAndroid(private val tts: AndroidTTS) : TextToSpeechInstance, Closeable {
     override var volume: Int = 100
+        set(value) {
+            if(TextToSpeech.canChangeVolume)
+                field = value
+        }
 
     override fun say(text: String, clearQueue: Boolean) {
         val queueMode = if(clearQueue) AndroidTTS.QUEUE_FLUSH else AndroidTTS.QUEUE_ADD

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -7,6 +7,5 @@ actual interface TextToSpeechInstance : Closeable {
 
     actual fun say(text: String, clearQueue: Boolean)
 
-    @Throws(Exception::class)
     actual override fun close()
 }

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -3,13 +3,19 @@ package nl.marc.tts
 import java.io.Closeable
 
 actual interface TextToSpeechInstance : Closeable {
+    /**
+     * The output volume, which is 100(%) by default.
+     * Value is minimally 0, maximally 100 (although some platforms may allow higher values).
+     */
     actual var volume: Int
 
     actual var isMuted: Boolean
 
     actual fun say(text: String, clearQueue: Boolean)
 
+    /** Clears the internal queue, but doesn't close used resources. */
     actual fun stop()
 
+    /** Clears the internal queue and closes used resources (if possible) */
     actual override fun close()
 }

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -5,7 +5,11 @@ import java.io.Closeable
 actual interface TextToSpeechInstance : Closeable {
     actual var volume: Int
 
+    actual var isMuted: Boolean
+
     actual fun say(text: String, clearQueue: Boolean)
+
+    actual fun stop()
 
     actual override fun close()
 }

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -11,6 +11,10 @@ actual interface TextToSpeechInstance : Closeable {
 
     actual var isMuted: Boolean
 
+    actual var pitch: Float
+
+    actual var rate: Float
+
     actual fun say(text: String, clearQueue: Boolean)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/androidMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -15,6 +15,12 @@ actual interface TextToSpeechInstance : Closeable {
 
     actual var rate: Float
 
+    /**
+     * Returns a BCP 47 language tag of the selected voice on supported platforms.
+     * May return the language code as ISO 639 on older platforms.
+     */
+    actual val language: String
+
     actual fun say(text: String, clearQueue: Boolean)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/browserMain/kotlin/nl/marc/tts/Context.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/Context.kt
@@ -1,0 +1,5 @@
+package nl.marc.tts
+
+import org.w3c.dom.Window
+
+actual typealias Context = Window

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeech.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeech.kt
@@ -10,6 +10,7 @@ actual object TextToSpeech {
      * Creates a new [TextToSpeech] instance.
      * Will throw an [TextToSpeechNotSupportedException] if TTS is not supported.
      */
+    @Throws(TextToSpeechNotSupportedException::class)
     fun createOrThrow(): TextToSpeechInstance {
         if(isSupported) return TextToSpeechJS()
         else throw TextToSpeechNotSupportedException()
@@ -21,5 +22,23 @@ actual object TextToSpeech {
      */
     fun createOrNull(): TextToSpeechInstance? {
         return if(isSupported) TextToSpeechJS() else null
+    }
+
+    /**
+     * Creates a new [TextToSpeech] instance.
+     * Will throw an [TextToSpeechNotSupportedException] if TTS is not supported.
+     */
+    @Throws(TextToSpeechNotSupportedException::class)
+    actual fun createOrThrow(context: Context, callback: (TextToSpeechInstance) -> Unit) {
+        if(isSupported) callback(TextToSpeechJS(context))
+        else throw TextToSpeechNotSupportedException()
+    }
+
+    /**
+     * Creates a new [TextToSpeech] instance.
+     * Will return null if TTS is not supported.
+     */
+    actual fun createOrNull(context: Context, callback: (TextToSpeechInstance?) -> Unit) {
+        callback(if(isSupported) TextToSpeechJS(context) else null)
     }
 }

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -10,6 +10,10 @@ actual interface TextToSpeechInstance {
 
     actual var isMuted: Boolean
 
+    actual var pitch: Float
+
+    actual var rate: Float
+
     actual fun say(text: String, clearQueue: Boolean)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -2,13 +2,19 @@ package nl.marc.tts
 
 @JsExport
 actual interface TextToSpeechInstance {
+    /**
+     * The output volume, which is 100(%) by default.
+     * Value is minimally 0, maximally 100 (although some platforms may allow higher values).
+     */
     actual var volume: Int
 
     actual var isMuted: Boolean
 
     actual fun say(text: String, clearQueue: Boolean)
 
+    /** Clears the internal queue, but doesn't close used resources. */
     actual fun stop()
 
+    /** Clears the internal queue and closes used resources (if possible) */
     actual fun close()
 }

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -4,7 +4,11 @@ package nl.marc.tts
 actual interface TextToSpeechInstance {
     actual var volume: Int
 
+    actual var isMuted: Boolean
+
     actual fun say(text: String, clearQueue: Boolean)
+
+    actual fun stop()
 
     actual fun close()
 }

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -14,6 +14,12 @@ actual interface TextToSpeechInstance {
 
     actual var rate: Float
 
+    /**
+     * Returns a BCP 47 language tag of the selected voice on supported platforms.
+     * May return the language code as ISO 639 on older platforms.
+     */
+    actual val language: String
+
     actual fun say(text: String, clearQueue: Boolean)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
@@ -14,10 +14,19 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
 
     private val speechSynthesisUtterance = SpeechSynthesisUtterance()
 
-    override var volume: Int
-        get() = (speechSynthesisUtterance.volume * 100).roundToInt()
+    private val internalVolume: Float
+        get() = if(!isMuted) volume.toFloat() else 0f
+
+    override var volume: Int = 100
         set(value) {
-            speechSynthesisUtterance.volume = value / 100f
+            field = value
+            speechSynthesisUtterance.volume = internalVolume
+        }
+
+    override var isMuted = false
+        set(value) {
+            field = value
+            speechSynthesisUtterance.volume = internalVolume
         }
 
     override fun say(text: String, clearQueue: Boolean) {
@@ -25,8 +34,11 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
         speechSynthesis.speak(speechSynthesisUtterance)
     }
 
+    override fun stop() {
+        speechSynthesis.cancel()
+    }
+
     override fun close() {
-        speechSynthesis.pause()
         speechSynthesis.cancel()
     }
 }

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
@@ -17,6 +17,10 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
     private val internalVolume: Float
         get() = if(!isMuted) volume.toFloat() else 0f
 
+    /**
+     * The output volume, which is 100(%) by default.
+     * Value is minimally 0, maximally 100 (although some platforms may allow higher values).
+     */
     override var volume: Int = 100
         set(value) {
             field = value
@@ -30,14 +34,17 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
         }
 
     override fun say(text: String, clearQueue: Boolean) {
+        if(clearQueue) speechSynthesis.cancel()
         speechSynthesisUtterance.text = text
         speechSynthesis.speak(speechSynthesisUtterance)
     }
 
+    /** Clears the internal queue, but doesn't close used resources. */
     override fun stop() {
         speechSynthesis.cancel()
     }
 
+    /** Clears the internal queue and closes used resources (if possible) */
     override fun close() {
         speechSynthesis.cancel()
     }

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
@@ -33,6 +33,18 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
             speechSynthesisUtterance.volume = internalVolume
         }
 
+    override var pitch: Float
+        get() = speechSynthesisUtterance.pitch
+        set(value) {
+            speechSynthesisUtterance.pitch = value
+        }
+
+    override var rate: Float
+        get() = speechSynthesisUtterance.rate
+        set(value) {
+            speechSynthesisUtterance.rate = value
+        }
+
     override fun say(text: String, clearQueue: Boolean) {
         if(clearQueue) speechSynthesis.cancel()
         speechSynthesisUtterance.text = text

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
@@ -2,14 +2,15 @@
 
 package nl.marc.tts
 
+import org.w3c.dom.Window
 import kotlin.browser.window
 import org.w3c.speech.SpeechSynthesis
 import org.w3c.speech.SpeechSynthesisUtterance
 import org.w3c.speech.speechSynthesis
 import kotlin.math.roundToInt
 
-internal class TextToSpeechJS : TextToSpeechInstance {
-    private val speechSynthesis: SpeechSynthesis = window.speechSynthesis
+internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
+    private val speechSynthesis: SpeechSynthesis = context.speechSynthesis
 
     private val speechSynthesisUtterance = SpeechSynthesisUtterance()
 

--- a/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
+++ b/src/browserMain/kotlin/nl/marc/tts/TextToSpeechJS.kt
@@ -45,6 +45,13 @@ internal class TextToSpeechJS(context: Window = window) : TextToSpeechInstance {
             speechSynthesisUtterance.rate = value
         }
 
+    /**
+     * Returns a BCP 47 language tag of the selected voice on supported platforms.
+     * May return the language code as ISO 639 on older platforms.
+     */
+    override val language: String
+        get() = speechSynthesisUtterance.voice.lang
+
     override fun say(text: String, clearQueue: Boolean) {
         if(clearQueue) speechSynthesis.cancel()
         speechSynthesisUtterance.text = text

--- a/src/commonMain/kotlin/nl/marc/tts/Context.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/Context.kt
@@ -1,0 +1,3 @@
+package nl.marc.tts
+
+expect abstract class Context

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeech.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeech.kt
@@ -4,4 +4,9 @@ expect object TextToSpeech {
     val isSupported: Boolean
 
     val canChangeVolume: Boolean
+
+    @Throws(TextToSpeechNotSupportedException::class)
+    fun createOrThrow(context: Context, callback: (TextToSpeechInstance) -> Unit)
+
+    fun createOrNull(context: Context, callback: (TextToSpeechInstance?) -> Unit)
 }

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -3,7 +3,11 @@ package nl.marc.tts
 expect interface TextToSpeechInstance {
     var volume: Int
 
+    var isMuted: Boolean
+
     fun say(text: String, clearQueue: Boolean = false)
+
+    fun stop()
 
     fun close()
 }

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -13,6 +13,12 @@ expect interface TextToSpeechInstance {
 
     var rate: Float
 
+    /**
+     * Returns a BCP 47 language tag of the selected voice on supported platforms.
+     * May return the language code as ISO 639 on older platforms.
+     */
+    val language: String
+
     fun say(text: String, clearQueue: Boolean = false)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -5,6 +5,5 @@ expect interface TextToSpeechInstance {
 
     fun say(text: String, clearQueue: Boolean = false)
 
-    @Throws(Exception::class)
     fun close()
 }

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -9,6 +9,10 @@ expect interface TextToSpeechInstance {
 
     var isMuted: Boolean
 
+    var pitch: Float
+
+    var rate: Float
+
     fun say(text: String, clearQueue: Boolean = false)
 
     /** Clears the internal queue, but doesn't close used resources. */

--- a/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
+++ b/src/commonMain/kotlin/nl/marc/tts/TextToSpeechInstance.kt
@@ -1,13 +1,19 @@
 package nl.marc.tts
 
 expect interface TextToSpeechInstance {
+    /**
+     * The output volume, which is 100(%) by default.
+     * Value is minimally 0, maximally 100 (although some platforms may allow higher values).
+     */
     var volume: Int
 
     var isMuted: Boolean
 
     fun say(text: String, clearQueue: Boolean = false)
 
+    /** Clears the internal queue, but doesn't close used resources. */
     fun stop()
 
+    /** Clears the internal queue and closes used resources (if possible) */
     fun close()
 }


### PR DESCRIPTION
# Common
- Create a TextToSpeechInstance from common code (you'll still need an instance of a context object: `android.content.Context` on Android or `org.w3c.dom.Window` in the browser)
- Getter and setter for pitch
- Getter and setter for rate
- Getter for language
- Getter and setter for mute
- Stop method, which clears the TTS queue
- Documentation enhancements

# Android
- The `TextToSpeechInstance.close()` method is now annotated with `@Throws(IOException::class)` instead of `@Throws(Exception::class)`

# Browser
- Bugfix where clearQueue (see `TextToSpeechInstance.say()`) would have no effect
- You can now provide a custom `Window` object upon TTS creation